### PR TITLE
Hide default connect messages

### DIFF
--- a/lua/autorun/client/cl_apple.lua
+++ b/lua/autorun/client/cl_apple.lua
@@ -42,3 +42,7 @@ net.Receive( "cfc_playerdisconnect_ajl", function()
 
     chat.AddText( prefixColor, "[Server] ", teamCol, name, textColor, " (" .. sID .. ") has left the server. (" .. reason .. ")" )
 end)
+
+hook.Add( "ChatText", "CFC_ChatText_AppleJoinLeave", function( _, _, _, msgType )
+    if msgType == "joinleave" then return true end
+end )


### PR DESCRIPTION
Removes the default join and leave messages

Before:
![image](https://user-images.githubusercontent.com/69946827/165296073-34b73362-2cd2-4228-befc-e9106ebd9c67.png)
After:
![image](https://user-images.githubusercontent.com/69946827/165296125-7af121a6-7e6d-44ad-977b-a69e2b6003d4.png)
